### PR TITLE
fix: Too many network calls happen on scrolling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "axios": "^1.4.0",
         "eslint": "8.43.0",
         "eslint-config-next": "13.4.7",
+        "lodash.debounce": "^4.0.8",
         "next": "13.4.7",
         "notistack": "^3.0.1",
         "react": "18.2.0",
@@ -3342,6 +3343,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "axios": "^1.4.0",
     "eslint": "8.43.0",
     "eslint-config-next": "13.4.7",
+    "lodash.debounce": "^4.0.8",
     "next": "13.4.7",
     "notistack": "^3.0.1",
     "react": "18.2.0",

--- a/src/app/Posts/page.tsx
+++ b/src/app/Posts/page.tsx
@@ -12,6 +12,7 @@ import Header from "../../Components/Header/Header";
  * The page component fetches user data from an API and displays a button to load more data.
  */
 const Page = () => {
+  const debounce = require('lodash.debounce');
   const [userData, setUserData] = useState<any[]>([]); // Specify the type as 'empty array'
   const [userPage, setUserPage] = useState<number>(0); // Specify the type as 'number'
   const [processBar, setProcessbar] = useState<boolean>(false); // Specify the type as 'number'
@@ -42,13 +43,13 @@ const Page = () => {
 
     fetchData();
 
-    const handleOnScroll = () => {
+    const handleOnScroll = debounce(() => {
       setUserPage(userPage + 1);
       setProcessbar(true);
       setTimeout(() => {
         setProcessbar(false);
       }, 1000);
-    };
+    },1000);
     if (typeof window !== "undefined") {
       window.addEventListener("scroll", handleOnScroll);
     }


### PR DESCRIPTION
Hello, @imkuldeepahlawat. I have checked that your website had too many network requests upon scrolling down the page because of the infinite scrolling without throttling. I have added debouncing to the page.tsx file and there is significant change in the number of network requests per scroll. Please review. Fixes: #1 